### PR TITLE
[#4] Inroduce Timestamp and functions

### DIFF
--- a/o-clock.cabal
+++ b/o-clock.cabal
@@ -47,7 +47,8 @@ test-suite o-clock-test
   hs-source-dirs:      test
   main-is:             Spec.hs
 
-  other-modules:       Test.Time.TypeSpec
+  other-modules:       Test.Time.TimeStamp
+                       Test.Time.TypeSpec
                        Test.Time.Units
 
   build-depends:       base         >= 4.11  && < 5

--- a/o-clock.cabal
+++ b/o-clock.cabal
@@ -23,6 +23,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Time
                          Time.Rational
+                         Time.Timestamp
                          Time.Units
   ghc-options:         -Wall
   build-depends:       base         >= 4.11

--- a/o-clock.cabal
+++ b/o-clock.cabal
@@ -23,10 +23,11 @@ library
   hs-source-dirs:      src
   exposed-modules:     Time
                          Time.Rational
-                         Time.Timestamp
+                         Time.TimeStamp
                          Time.Units
   ghc-options:         -Wall
   build-depends:       base         >= 4.11
+                     , ghc-prim     >= 0.5
                      , transformers >= 0.5
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings

--- a/src/Time.hs
+++ b/src/Time.hs
@@ -1,9 +1,9 @@
 module Time
     ( module Time.Rational
-    , module Time.Timestamp
+    , module Time.TimeStamp
     , module Time.Units
     ) where
 
 import Time.Rational
-import Time.Timestamp
+import Time.TimeStamp
 import Time.Units

--- a/src/Time.hs
+++ b/src/Time.hs
@@ -1,7 +1,9 @@
 module Time
     ( module Time.Rational
+    , module Time.Timestamp
     , module Time.Units
     ) where
 
 import Time.Rational
+import Time.Timestamp
 import Time.Units

--- a/src/Time/TimeStamp.hs
+++ b/src/Time/TimeStamp.hs
@@ -1,33 +1,32 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE Rank2Types                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 
-module Time.Timestamp
-       ( Timestamp (..)
+module Time.TimeStamp
+       ( TimeStamp (..)
        , timeDiff
        , timeAdd
        , timeMul
        , timeDiv
        ) where
 
-import GHC.Real (denominator, numerator, (%))
-
 import Time.Rational (KnownRat, RatioNat)
 import Time.Units (Time (..))
 
 -- | Similar to 'Time' but has no units and can be negative.
-newtype Timestamp = Timestamp Rational
+newtype TimeStamp = TimeStamp Rational
     deriving (Show, Read, Num, Eq, Ord, Enum, Fractional, Real, RealFrac)
 
 
 -- | Returns the result of comparison of two 'Timestamp's and
 -- the 'Time' of that difference of given time unit.
-timeDiff :: KnownRat unit => Timestamp -> Timestamp -> (Ordering, Time unit)
-timeDiff (Timestamp a) (Timestamp b) =
-    let order         = compare a b
-        dif           = abs (a - b)
-        t :: RatioNat = fromIntegral (numerator dif) % fromIntegral (denominator dif)
-    in (order, Time t)
+timeDiff :: KnownRat unit => TimeStamp -> TimeStamp -> (Ordering, Time unit)
+timeDiff (TimeStamp a) (TimeStamp b) =
+    let order = compare a b
+        d = fromRational $ case order of
+                EQ -> 0
+                GT -> a - b
+                LT -> b - a
+    in (order, d)
 
 -- | Returns the result of addition of two 'Time' elements.
 timeAdd :: KnownRat unit => Time unit -> Time unit -> Time unit

--- a/src/Time/Timestamp.hs
+++ b/src/Time/Timestamp.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE Rank2Types                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+module Time.Timestamp
+       ( Timestamp (..)
+       , timeDiff
+       , timeAdd
+       , timeMul
+       , timeDiv
+       ) where
+
+import GHC.Real (denominator, numerator, (%))
+
+import Time.Rational (KnownRat, RatioNat)
+import Time.Units (Time (..))
+
+-- | Similar to 'Time' but has no units and can be negative.
+newtype Timestamp = Timestamp Rational
+    deriving (Show, Read, Num, Eq, Ord, Enum, Fractional, Real, RealFrac)
+
+
+-- | Returns the result of comparison of two 'Timestamp's and
+-- the 'Time' of that difference of given time unit.
+timeDiff :: KnownRat unit => Timestamp -> Timestamp -> (Ordering, Time unit)
+timeDiff (Timestamp a) (Timestamp b) =
+    let order         = compare a b
+        dif           = abs (a - b)
+        t :: RatioNat = fromIntegral (numerator dif) % fromIntegral (denominator dif)
+    in (order, Time t)
+
+-- | Returns the result of addition of two 'Time' elements.
+timeAdd :: KnownRat unit => Time unit -> Time unit -> Time unit
+timeAdd = (+)
+
+-- | Returns the result of multiplication of two 'Time' elements.
+timeMul :: KnownRat unit => RatioNat -> Time unit -> Time unit
+timeMul n (Time t) = Time (n * t)
+
+-- | Returns the result of division of two 'Time' elements.
+timeDiv :: KnownRat unit => Time unit -> Time unit -> RatioNat
+timeDiv (Time t1) (Time t2) = t1 / t2

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,11 +1,21 @@
 module Main where
 
+import Test.Tasty (defaultMain, testGroup)
+
+import Test.Time.TimeStamp (timeStampTestTree)
 import Test.Time.TypeSpec (runTypeSpecTests)
-import Test.Time.Units (runTests)
+import Test.Time.Units (unitsTestTree)
 
 main :: IO ()
 main = do
     -- type specs
     runTypeSpecTests
-    -- convertUnit tests with tasty
-    runTests
+    -- Units tests with tasty:
+    -- * convertUnit tests
+    -- * read tests
+    unitTests <- unitsTestTree
+    -- TimeStamp tests
+    tsTests   <- timeStampTestTree
+
+    let allTests = testGroup "O'Clock" [unitTests, tsTests]
+    defaultMain allTests

--- a/test/Test/Time/TimeStamp.hs
+++ b/test/Test/Time/TimeStamp.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE TypeOperators      #-}
+
+module Test.Time.TimeStamp
+       ( timeStampTestTree
+       ) where
+
+import Control.Exception (evaluate)
+import Test.Tasty (TestTree)
+import Test.Tasty.Hspec (Spec, anyException, describe, it, shouldBe, shouldThrow, testSpec)
+
+import Time (DayUnit, HourUnit, MicroSecondUnit, MilliSecondUnit, SecondUnit, TimeStamp (..),
+             WeekUnit, timeAdd, timeDiff, timeDiv, timeMul)
+
+timeStampTestTree :: IO TestTree
+timeStampTestTree = testSpec "TimeStamp and time operations" spec_TimeStamp
+
+
+spec_TimeStamp :: Spec
+spec_TimeStamp = do
+    describe "TimeDiff" $ do
+        it "1 is less than 5, diff is 4 seconds" $
+            timeDiff @SecondUnit (TimeStamp 1) (TimeStamp 5) `shouldBe` (LT, 4)
+        it "100 is greater that 11, diff is 89 Days" $
+            timeDiff @DayUnit (TimeStamp 100) (TimeStamp 11) `shouldBe` (GT, 89)
+        it "42 is equal to 42, diff is 0 Weeks" $
+            timeDiff @WeekUnit (TimeStamp 42) (TimeStamp 42) `shouldBe` (EQ, 0)
+        it "3 hours + 7 hours is 10"  $
+            timeAdd @HourUnit 3 7 `shouldBe` 10
+        it "twice 21 mcs is 42 mcs"  $
+            timeMul @MicroSecondUnit 2 21 `shouldBe` 42
+        it "zero x 42 s is zero"  $
+            timeMul @SecondUnit 0 42 `shouldBe` 0
+        it "84 seconds divide by 2 is 42"  $
+            timeDiv @MilliSecondUnit 84 2 `shouldBe` 42
+        it "fails when trying to divide by zero"  $
+            evaluate (timeDiv @SecondUnit 42 0) `shouldThrow` anyException

--- a/test/Test/Time/Units.hs
+++ b/test/Test/Time/Units.hs
@@ -4,25 +4,19 @@
 {-# LANGUAGE TypeOperators      #-}
 
 module Test.Time.Units
-       ( runTests
+       ( unitsTestTree
        ) where
 
 import Control.Exception (evaluate)
 import GHC.Real (Ratio ((:%)))
-import Test.Tasty (TestTree, defaultMain)
+import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (Spec, anyException, describe, it, shouldBe, shouldThrow, testSpec)
 
 import Time (DayUnit, Hour, MicroSecond, MicroSecondUnit, MilliSecondUnit, Second, SecondUnit,
              Time (..), WeekUnit, convertUnit, day, fortnight, mcs, ms, sec)
 
-runTests :: IO ()
-runTests = do
-    tests <- specTests
-    defaultMain tests
-
-specTests :: IO TestTree
-specTests = testSpec "Units" spec_Units
-
+unitsTestTree :: IO TestTree
+unitsTestTree = testSpec "Units" spec_Units
 
 spec_Units :: Spec
 spec_Units = do


### PR DESCRIPTION
Resolves #4 
Resolves #14 (`Num` and  `Fraction` instances are rewritten manually with `error` on `*` and `/` operators)