### PR TITLE
[#19] Add Formatting module

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Since this tutorial is literate haskell file, let's first write some pragmas and
 
 module Main where
 
-import Time ((:%), Time, Hour, HourUnit, UnitName, type (*), floorUnit, toUnit)
+import Time ((:%), Time, Hour, HourUnit, UnitName, type (*), floorUnit, hour, seriesF, toUnit)
 ```
 
 ### Introduce custom units
@@ -114,9 +114,14 @@ formatHours :: Hour -> String
 formatHours hours = let (weeks, days) = calculateWork hours in show weeks ++ show days
 ```
 
-After that we can simply write:
+After that we can simply print the output we wanted.
+
+Thought we have special function for this kind of formatting purposes `seriesF`.
+So the same result can be gained with the usage of it. Check it out:
 
 ```haskell
 main :: IO ()
-main = putStrLn $ formatHours 140
+main = do
+    putStrLn $ formatHours 140
+    putStrLn $ seriesF @'[WorkWeek, WorkDay] $ hour 140
 ```

--- a/o-clock.cabal
+++ b/o-clock.cabal
@@ -23,6 +23,7 @@ source-repository head
 library
   hs-source-dirs:      src
   exposed-modules:     Time
+                         Time.Formatting
                          Time.Rational
                          Time.TimeStamp
                          Time.Units

--- a/src/Time.hs
+++ b/src/Time.hs
@@ -4,11 +4,13 @@
 -- can be found here: <https://github.com/serokell/o-clock#readme>
 
 module Time
-    ( module Time.Rational
+    ( module Time.Formatting
+    , module Time.Rational
     , module Time.TimeStamp
     , module Time.Units
     ) where
 
+import Time.Formatting
 import Time.Rational
 import Time.TimeStamp
 import Time.Units

--- a/src/Time/Formatting.hs
+++ b/src/Time/Formatting.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE InstanceSigs        #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE Rank2Types          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+-- | This module introduces function to format time in desired way.
+--
+-- Here will be some examples after design is approved.
+
+module Time.Formatting
+       ( Series (..)
+       ) where
+
+import Time.Rational (KnownRat, Rat, withRuntimeDivRat)
+import Time.Units (KnownUnitSymbol, Time, floorUnit, toUnit)
+
+-- | Class for time formatting.
+class Series (units :: [Rat]) where
+    seriesF :: forall unit . (KnownUnitSymbol unit, KnownRat unit)
+            => Time unit
+            -> String
+
+instance Series ('[] :: [Rat]) where
+    seriesF _ = ""
+
+instance (KnownUnitSymbol unit, KnownRat unit, Series units) => Series (unit ': units :: [Rat]) where
+   seriesF :: forall unit' .
+              (KnownUnitSymbol unit', KnownRat unit')
+           => Time unit'
+           -> String
+   seriesF t = let newUnit = withRuntimeDivRat @unit' @unit $ toUnit @(Time unit) t
+                   format  = floorUnit newUnit
+               in show format ++ seriesF @units @unit (newUnit - format)

--- a/src/Time/Formatting.hs
+++ b/src/Time/Formatting.hs
@@ -8,31 +8,58 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
 
--- | This module introduces function to format time in desired way.
---
--- Here will be some examples after design is approved.
+{- | This module introduces function to format time in desired way.
+
+__Examples__
+
+>>> seriesF @'[DayUnit, HourUnit, MinuteUnit, SecondUnit] (minute 4000)
+"2d18h40m"
+
+>>> seriesF @'[DayUnit, MinuteUnit, SecondUnit] (minute 4000)
+"2d1120m"
+
+>>>  seriesF @'[HourUnit, SecondUnit, MillisecondUnit] (Time @MinuteUnit $ 3 % 2)
+"90s"
+
+-}
 
 module Time.Formatting
        ( Series (..)
+       , unitsF
        ) where
 
-import Time.Rational (KnownRat, Rat, withRuntimeDivRat)
-import Time.Units (KnownUnitSymbol, Time, floorUnit, toUnit)
+import Time.Rational (Rat, withRuntimeDivRat)
+import Time.Units (AllUnits, KnownRatName, Time, floorUnit, toUnit)
 
 -- | Class for time formatting.
 class Series (units :: [Rat]) where
-    seriesF :: forall unit . (KnownUnitSymbol unit, KnownRat unit)
+    seriesF :: forall unit . KnownRatName unit
             => Time unit
             -> String
 
 instance Series ('[] :: [Rat]) where
+    seriesF :: Time someUnit -> String
     seriesF _ = ""
 
-instance (KnownUnitSymbol unit, KnownRat unit, Series units) => Series (unit ': units :: [Rat]) where
-   seriesF :: forall unit' .
-              (KnownUnitSymbol unit', KnownRat unit')
-           => Time unit'
+instance (KnownRatName unit, Series units) => Series (unit ': units :: [Rat]) where
+   seriesF :: forall someUnit . (KnownRatName someUnit)
+           => Time someUnit
            -> String
-   seriesF t = let newUnit = withRuntimeDivRat @unit' @unit $ toUnit @(Time unit) t
+   seriesF t = let newUnit = withRuntimeDivRat @someUnit @unit $ toUnit @(Time unit) t
                    format  = floorUnit newUnit
-               in show format ++ seriesF @units @unit (newUnit - format)
+                   timeStr = case (floor @(Time unit) newUnit :: Int) of
+                                  0 -> ""
+                                  _ -> show format
+               in timeStr ++ seriesF @units @unit (newUnit - format)
+
+{- | Similar to 'seriesF', but formats using all time units of the library.
+
+>>> unitsF $ fortnight 5
+"5fn"
+
+>>> unitsF $ minute 4000
+"2d18h40m"
+
+-}
+unitsF :: forall unit . KnownRatName unit => Time unit -> String
+unitsF = seriesF @AllUnits

--- a/src/Time/Formatting.hs
+++ b/src/Time/Formatting.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE InstanceSigs         #-}
-{-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE Rank2Types           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeApplications     #-}
@@ -51,9 +50,9 @@ instance (time ~ Time unit, KnownRatName unit, Series times)
     seriesF :: forall someTime someUnit . (someTime ~ Time someUnit, KnownRatName someUnit)
             => someTime
             -> String
-    seriesF t = let newUnit = withRuntimeDivRat @someUnit @unit $ toUnit @(Time unit) t
+    seriesF t = let newUnit = withRuntimeDivRat @someUnit @unit $ toUnit @time t
                     format  = floorUnit newUnit
-                    timeStr = case (floor @time newUnit :: Int) of
+                    timeStr = case floor @time newUnit :: Int of
                                    0 -> ""
                                    _ -> show format
                 in timeStr ++ seriesF @times @unit (newUnit - format)

--- a/src/Time/Units.hs
+++ b/src/Time/Units.hs
@@ -63,6 +63,8 @@ module Time.Units
        , week
        , fortnight
 
+       , (+:)
+
         -- ** Functions
        , toUnit
        , threadDelay
@@ -298,6 +300,18 @@ fortnight = time
 -}
 floorUnit :: forall time unit . (time ~ Time unit) => time -> time
 floorUnit = time . floor
+
+-- | Sums times of different units.
+--
+-- >>> minute 1 +: sec 1
+-- 61s
+--
+(+:) :: forall timeB timeA b a . (timeA ~ Time a, timeB ~ Time b, KnownDivRat a b)
+     => timeA
+     -> timeB
+     -> timeB
+t1 +: t2 = toUnit t1 + t2
+{-# INLINE (+:) #-}
 
 ----------------------------------------------------------------------------
 -- Functional

--- a/src/Time/Units.hs
+++ b/src/Time/Units.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE ExplicitForAll             #-}
 {-# LANGUAGE FlexibleContexts           #-}
@@ -41,6 +42,7 @@ module Time.Units
        , FortnightUnit
 
        , UnitName
+       , KnownUnitSymbol
 
         -- ** Creation helpers
        , time
@@ -135,14 +137,17 @@ type instance UnitName (86400   :% 1) = "d"  -- day unit
 type instance UnitName (604800  :% 1) = "w"  -- week unit
 type instance UnitName (1209600 :% 1) = "fn" -- fortnight unit
 
-instance KnownSymbol (UnitName unit) => Show (Time unit) where
+-- | Constraint alias for 'KnownSymbol' 'UnitName'.
+type KnownUnitSymbol unit = KnownSymbol (UnitName unit)
+
+instance KnownUnitSymbol unit => Show (Time unit) where
     show (Time rat) = let numeratorStr   = show (numerator rat)
                           denominatorStr = case denominator rat of
                                                 1 -> ""
                                                 n -> '/' : show n
                       in numeratorStr ++ denominatorStr ++ symbolVal (Proxy @(UnitName unit))
 
-instance KnownSymbol (UnitName unit) => Read (Time unit) where
+instance KnownUnitSymbol unit => Read (Time unit) where
     readPrec :: ReadPrec (Time unit)
     readPrec = lift readP
       where

--- a/src/Time/Units.hs
+++ b/src/Time/Units.hs
@@ -29,6 +29,8 @@ module Time.Units
        , Week
        , Fortnight
 
+       , AllTimes
+
          -- ** Units
        , SecondUnit
        , MillisecondUnit
@@ -40,8 +42,6 @@ module Time.Units
        , DayUnit
        , WeekUnit
        , FortnightUnit
-
-       , AllUnits
 
        , UnitName
        , KnownUnitName
@@ -109,12 +109,6 @@ type DayUnit         = 24 * HourUnit
 type WeekUnit        = 7  * DayUnit
 type FortnightUnit   = 2  * WeekUnit
 
--- | Type-level list that consist of all time units.
-type AllUnits =
-  '[ FortnightUnit, WeekUnit, DayUnit, HourUnit, MinuteUnit, SecondUnit
-   , MillisecondUnit , MicrosecondUnit, NanosecondUnit, PicosecondUnit
-   ]
-
 ----------------------------------------------------------------------------
 -- Time data type
 ----------------------------------------------------------------------------
@@ -130,6 +124,13 @@ type Hour        = Time HourUnit
 type Day         = Time DayUnit
 type Week        = Time WeekUnit
 type Fortnight   = Time FortnightUnit
+
+-- | Type-level list that consist of all time.
+type AllTimes =
+  '[ Fortnight, Week, Day, Hour, Minute, Second
+   , Millisecond , Microsecond, Nanosecond, Picosecond
+   ]
+
 
 -- | Type family for prettier 'show' of time units.
 type family UnitName (unit :: Rat) :: Symbol

--- a/test/Test/Time/Property.hs
+++ b/test/Test/Time/Property.hs
@@ -16,9 +16,9 @@ import Hedgehog (MonadGen, MonadTest, Property, PropertyT, forAll, property, (==
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testProperty)
 
-import Time (DayUnit, FortnightUnit, HourUnit, KnownRat, KnownUnitSymbol, MicrosecondUnit,
+import Time (DayUnit, FortnightUnit, HourUnit, KnownRat, KnownRatName, MicrosecondUnit,
              MillisecondUnit, MinuteUnit, NanosecondUnit, PicosecondUnit, Rat, RatioNat, SecondUnit,
-             Time (..), UnitName, WeekUnit, toUnit, withRuntimeDivRat)
+             Time (..), WeekUnit, toUnit, withRuntimeDivRat)
 
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -33,7 +33,7 @@ toUnitTestTree :: TestTree
 toUnitTestTree = testProperty "Hedgehog toUnit @to @from . toUnit @from @to ≡ id' property" prop_toUnit
 
 -- | Existential data type for 'Unit's.
-data AnyTime =  forall (unit :: Rat) . (KnownRat unit, KnownUnitSymbol unit)
+data AnyTime =  forall (unit :: Rat) . (KnownRatName unit)
              => MkAnyTime (Time unit)
 
 instance Show AnyTime where
@@ -63,7 +63,7 @@ verifyToUnit :: forall m . (MonadTest m) => AnyTime -> AnyTime -> m ()
 verifyToUnit (MkAnyTime t1) (MkAnyTime t2) = checkToUnit t1 t2
   where
     checkToUnit :: forall (unitFrom :: Rat) (unitTo :: Rat) .
-                   (KnownUnitSymbol unitFrom, KnownRat unitFrom, KnownRat unitTo)
+                   (KnownRatName unitFrom, KnownRat unitTo)
                 => Time unitFrom
                 -> Time unitTo
                 -> m ()

--- a/test/Test/Time/Property.hs
+++ b/test/Test/Time/Property.hs
@@ -12,14 +12,13 @@ module Test.Time.Property
 
 import GHC.Natural (Natural)
 import GHC.Real ((%))
-import GHC.TypeLits (KnownSymbol)
 import Hedgehog (MonadGen, MonadTest, Property, PropertyT, forAll, property, (===))
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testProperty)
 
-import Time (DayUnit, FortnightUnit, HourUnit, KnownRat, MicrosecondUnit, MillisecondUnit,
-             MinuteUnit, NanosecondUnit, PicosecondUnit, Rat, RatioNat, SecondUnit, Time (..),
-             UnitName, WeekUnit, toUnit, withRuntimeDivRat)
+import Time (DayUnit, FortnightUnit, HourUnit, KnownRat, KnownUnitSymbol, MicrosecondUnit,
+             MillisecondUnit, MinuteUnit, NanosecondUnit, PicosecondUnit, Rat, RatioNat, SecondUnit,
+             Time (..), UnitName, WeekUnit, toUnit, withRuntimeDivRat)
 
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -34,7 +33,7 @@ toUnitTestTree :: TestTree
 toUnitTestTree = testProperty "Hedgehog toUnit @to @from . toUnit @from @to ≡ id' property" prop_toUnit
 
 -- | Existential data type for 'Unit's.
-data AnyTime =  forall (unit :: Rat) . (KnownRat unit, KnownSymbol (UnitName unit))
+data AnyTime =  forall (unit :: Rat) . (KnownRat unit, KnownUnitSymbol unit)
              => MkAnyTime (Time unit)
 
 instance Show AnyTime where
@@ -64,7 +63,7 @@ verifyToUnit :: forall m . (MonadTest m) => AnyTime -> AnyTime -> m ()
 verifyToUnit (MkAnyTime t1) (MkAnyTime t2) = checkToUnit t1 t2
   where
     checkToUnit :: forall (unitFrom :: Rat) (unitTo :: Rat) .
-                   (KnownSymbol (UnitName unitFrom), KnownRat unitFrom, KnownRat unitTo)
+                   (KnownUnitSymbol unitFrom, KnownRat unitFrom, KnownRat unitTo)
                 => Time unitFrom
                 -> Time unitTo
                 -> m ()

--- a/test/Test/Time/Units.hs
+++ b/test/Test/Time/Units.hs
@@ -12,9 +12,9 @@ import GHC.Real (Ratio ((:%)))
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (Spec, anyException, describe, it, shouldBe, shouldThrow, testSpec)
 
-import Time (Day, DayUnit, Hour, HourUnit, Microsecond, Millisecond, MillisecondUnit, MinuteUnit,
-             Picosecond, Second, SecondUnit, Time (..), Week, WeekUnit, day, floorUnit, fortnight,
-             mcs, minute, ms, ns, ps, sec, seriesF, toUnit, unitsF)
+import Time (Day, Hour, HourUnit, Microsecond, Millisecond, Minute, MinuteUnit, Picosecond, Second,
+             SecondUnit, Time (..), Week, day, floorUnit, fortnight, mcs, minute, ms, ns, ps, sec,
+             seriesF, toUnit, unitsF)
 
 unitsTestTree :: IO TestTree
 unitsTestTree = testSpec "Units" spec_Units
@@ -62,15 +62,15 @@ spec_Units = do
             floorUnit (ps 42) `shouldBe` 42
     describe "Formatting tests" $ do
         it "4000 minutes should be formatted without ending-zeros" $
-            seriesF @'[DayUnit, HourUnit, MinuteUnit, SecondUnit] (minute 4000) `shouldBe` "2d18h40m"
+            seriesF @'[Day, Hour, Minute, Second] (minute 4000) `shouldBe` "2d18h40m"
         it "4000 minutes should be formatted without beginning-zeros" $
-            seriesF @'[WeekUnit, DayUnit, HourUnit, MinuteUnit] (minute 4000) `shouldBe` "2d18h40m"
+            seriesF @'[Week, Day, Hour, Minute] (minute 4000) `shouldBe` "2d18h40m"
         it "3601 sec should be formatted without middle-zeros" $
-            seriesF @'[HourUnit, MinuteUnit, SecondUnit] (sec 3601) `shouldBe` "1h1s"
+            seriesF @'[Hour, Minute, Second] (sec 3601) `shouldBe` "1h1s"
         it "works on rational nums" $
-            seriesF @'[HourUnit, SecondUnit, MillisecondUnit] (Time @MinuteUnit $ 3 :% 2) `shouldBe` "90s"
+            seriesF @'[Hour, Second, Millisecond] (Time @MinuteUnit $ 3 :% 2) `shouldBe` "90s"
         it "works without minutes formatting" $
-            seriesF @'[DayUnit, MinuteUnit, SecondUnit] (minute 4000) `shouldBe` "2d1120m"
+            seriesF @'[Day, Minute, Second] (minute 4000) `shouldBe` "2d1120m"
 
         it "4000 minutes should be formatted like 2d18h40m" $
             unitsF (minute 4000) `shouldBe` "2d18h40m"

--- a/test/Test/Time/Units.hs
+++ b/test/Test/Time/Units.hs
@@ -13,8 +13,8 @@ import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (Spec, anyException, describe, it, shouldBe, shouldThrow, testSpec)
 
 import Time (Day, Hour, HourUnit, Microsecond, Millisecond, Minute, MinuteUnit, Picosecond, Second,
-             SecondUnit, Time (..), Week, day, floorUnit, fortnight, mcs, minute, ms, ns, ps, sec,
-             seriesF, toUnit, unitsF)
+             SecondUnit, Time (..), Week, day, floorUnit, fortnight, hour, mcs, minute, ms, ns, ps,
+             sec, seriesF, toUnit, unitsF, week, (+:))
 
 unitsTestTree :: IO TestTree
 unitsTestTree = testSpec "Units" spec_Units
@@ -78,3 +78,7 @@ spec_Units = do
             unitsF (fortnight 42) `shouldBe` "42fn"
         it "empty when receive zero time" $
             unitsF (Time @HourUnit 0) `shouldBe` ""
+        it "sums all time units" $
+            unitsF (  fortnight 1 +: week 1 +: day 1 +: hour 1 +: minute 1
+                   +: sec 1 +: ms 1 +: mcs 1 +: ns 1 +: ps 1
+                   ) `shouldBe` "1fn1w1d1h1m1s1ms1mcs1ns1ps"

--- a/test/Test/Time/Units.hs
+++ b/test/Test/Time/Units.hs
@@ -12,8 +12,9 @@ import GHC.Real (Ratio ((:%)))
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (Spec, anyException, describe, it, shouldBe, shouldThrow, testSpec)
 
-import Time (Day, Hour, Microsecond, Millisecond, Picosecond, Second, SecondUnit, Time (..), Week,
-             day, floorUnit, fortnight, mcs, ms, ns, ps, sec, toUnit)
+import Time (Day, DayUnit, Hour, HourUnit, Microsecond, Millisecond, MillisecondUnit, MinuteUnit,
+             Picosecond, Second, SecondUnit, Time (..), Week, WeekUnit, day, floorUnit, fortnight,
+             mcs, minute, ms, ns, ps, sec, seriesF, toUnit, unitsF)
 
 unitsTestTree :: IO TestTree
 unitsTestTree = testSpec "Units" spec_Units
@@ -59,3 +60,21 @@ spec_Units = do
             floorUnit @Day (Time $ 5 :% 2) `shouldBe` 2
         it "returns 42ps when floor integer" $
             floorUnit (ps 42) `shouldBe` 42
+    describe "Formatting tests" $ do
+        it "4000 minutes should be formatted without ending-zeros" $
+            seriesF @'[DayUnit, HourUnit, MinuteUnit, SecondUnit] (minute 4000) `shouldBe` "2d18h40m"
+        it "4000 minutes should be formatted without beginning-zeros" $
+            seriesF @'[WeekUnit, DayUnit, HourUnit, MinuteUnit] (minute 4000) `shouldBe` "2d18h40m"
+        it "3601 sec should be formatted without middle-zeros" $
+            seriesF @'[HourUnit, MinuteUnit, SecondUnit] (sec 3601) `shouldBe` "1h1s"
+        it "works on rational nums" $
+            seriesF @'[HourUnit, SecondUnit, MillisecondUnit] (Time @MinuteUnit $ 3 :% 2) `shouldBe` "90s"
+        it "works without minutes formatting" $
+            seriesF @'[DayUnit, MinuteUnit, SecondUnit] (minute 4000) `shouldBe` "2d1120m"
+
+        it "4000 minutes should be formatted like 2d18h40m" $
+            unitsF (minute 4000) `shouldBe` "2d18h40m"
+        it "42 fortnights should be formatted like 42fn" $
+            unitsF (fortnight 42) `shouldBe` "42fn"
+        it "empty when receive zero time" $
+            unitsF (Time @HourUnit 0) `shouldBe` ""


### PR DESCRIPTION
Resolves #19 .

@ChShersh  for the moment it adds 0 timing everywhere (it could be in the beginning `0h4m2s`, in the middle `1h0m5s`, at the end `1h0m0s`). Could you please specify what interface do you prefer, or probably should make separate function on each case, so users can choose suitable for them behavior?