### PR TITLE
[#47] Rename SecondUnit -> Second (and others)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ With O'Clock you can write in several more convenient ways (and use more preferr
 
 ```haskell ignore
 threadDelay $ sec 5
-threadDelay (5 :: Second)
+threadDelay (5 :: Time Second)
 threadDelay @Second 5
 ```
 
@@ -73,7 +73,7 @@ Since this tutorial is literate haskell file, let's first write some pragmas and
 
 module Main where
 
-import Time ((:%), Time, Hour, HourUnit, UnitName, type (*), floorUnit, hour, seriesF, toUnit)
+import Time ((:%), Time, Hour, UnitName, type (*), floorUnit, hour, seriesF, toUnit)
 ```
 
 ### Introduce custom units
@@ -83,13 +83,10 @@ work day represented as `8` hours and work week represented as `5` work days.
 
 ```haskell
 -- | Time unit for a working day (8 hours).
-type WorkDayUnit = 8 * HourUnit
+type WorkDay = 8 * Hour
 
 -- | Time unit for a work week (5 working days).
-type WorkWeekUnit = 5 * WorkDayUnit
-
-type WorkDay  = Time WorkDayUnit
-type WorkWeek = Time WorkWeekUnit
+type WorkWeek = 5 * WorkDay
 
 -- this allows to use 'Show' and 'Read' functions for our time units
 type instance UnitName (28800  :% 1) = "wd"  -- One WorkDay  contains 28800  seconds
@@ -103,14 +100,14 @@ Now let's implement main logic of our application. Our main function should take
 convert them to work weeks and work days and then show in human readable format.
 
 ```haskell
-calculateWork :: Hour  -- type synonym for 'Time HourUnit'
-              -> (WorkWeek, WorkDay)
+calculateWork :: Time Hour  -- type synonym for 'Time HourUnit'
+              -> (Time WorkWeek, Time WorkDay)
 calculateWork workHours =
     let completeWeeks = floorUnit $ toUnit @WorkWeek workHours
         completeDays  = floorUnit $ toUnit @WorkDay  workHours - toUnit completeWeeks
     in (completeWeeks, completeDays)
 
-formatHours :: Hour -> String
+formatHours :: Time Hour -> String
 formatHours hours = let (weeks, days) = calculateWork hours in show weeks ++ show days
 ```
 

--- a/examples/Playground.hs
+++ b/examples/Playground.hs
@@ -2,11 +2,11 @@
 
 module Main where
 
-import Time (Second, threadDelay)
+import Time (Second, Time, threadDelay)
 
 main :: IO ()
 main = do
-    let twoSecs = 2 :: Second
+    let twoSecs = 2 :: Time Second
     putStrLn "Hello!"
     threadDelay twoSecs
     putStrLn "Hello after 2 seconds"

--- a/src/Time/Formatting.hs
+++ b/src/Time/Formatting.hs
@@ -32,30 +32,30 @@ module Time.Formatting
        , unitsF
        ) where
 
-import Time.Rational (withRuntimeDivRat)
+import Time.Rational (Rat, withRuntimeDivRat)
 import Time.Units (AllTimes, KnownRatName, Time, floorUnit, toUnit)
 
 -- | Class for time formatting.
-class Series (times :: [*]) where
-    seriesF :: forall unit . KnownRatName unit
-            => Time unit
+class Series (units :: [Rat]) where
+    seriesF :: forall (someUnit :: Rat) . KnownRatName someUnit
+            => Time someUnit
             -> String
 
-instance Series ('[] :: [*]) where
+instance Series ('[] :: [Rat]) where
     seriesF :: Time someUnit -> String
     seriesF _ = ""
 
-instance (time ~ Time unit, KnownRatName unit, Series times)
-    => Series (time ': times :: [*]) where
-    seriesF :: forall someTime someUnit . (someTime ~ Time someUnit, KnownRatName someUnit)
-            => someTime
+instance (KnownRatName unit, Series units)
+    => Series (unit ': units :: [Rat]) where
+    seriesF :: forall (someUnit :: Rat) . KnownRatName someUnit
+            => Time someUnit
             -> String
-    seriesF t = let newUnit = withRuntimeDivRat @someUnit @unit $ toUnit @time t
+    seriesF t = let newUnit = withRuntimeDivRat @someUnit @unit $ toUnit @unit t
                     format  = floorUnit newUnit
-                    timeStr = case floor @time newUnit :: Int of
+                    timeStr = case floor newUnit :: Int of
                                    0 -> ""
                                    _ -> show format
-                in timeStr ++ seriesF @times @unit (newUnit - format)
+                in timeStr ++ seriesF @units @unit (newUnit - format)
 
 {- | Similar to 'seriesF', but formats using all time units of the library.
 

--- a/src/Time/TimeStamp.hs
+++ b/src/Time/TimeStamp.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE ExplicitForAll             #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
@@ -14,7 +15,7 @@ module Time.TimeStamp
        , timeDiv
        ) where
 
-import Time.Rational (KnownRat, RatioNat)
+import Time.Rational (KnownRat, Rat, RatioNat)
 import Time.Units (Time (..))
 
 -- | Similar to 'Time' but has no units and can be negative.
@@ -24,10 +25,10 @@ newtype TimeStamp = TimeStamp Rational
 
 -- | Returns the result of comparison of two 'Timestamp's and
 -- the 'Time' of that difference of given time unit.
-timeDiff :: forall time unit . (time ~ Time unit, KnownRat unit)
+timeDiff :: forall (unit :: Rat) . KnownRat unit
          => TimeStamp
          -> TimeStamp
-         -> (Ordering, time)
+         -> (Ordering, Time unit)
 timeDiff (TimeStamp a) (TimeStamp b) =
     let order = compare a b
         d = fromRational $ case order of
@@ -37,22 +38,22 @@ timeDiff (TimeStamp a) (TimeStamp b) =
     in (order, d)
 
 -- | Returns the result of addition of two 'Time' elements.
-timeAdd :: forall time unit . (time ~ Time unit, KnownRat unit)
-        => time
-        -> time
-        -> time
+timeAdd :: forall (unit :: Rat) . KnownRat unit
+        => Time unit
+        -> Time unit
+        -> Time unit
 timeAdd = (+)
 
 -- | Returns the result of multiplication of two 'Time' elements.
-timeMul :: forall time unit . (time ~ Time unit, KnownRat unit)
+timeMul :: forall (unit :: Rat) . KnownRat unit
         => RatioNat
-        -> time
-        -> time
+        -> Time unit
+        -> Time unit
 timeMul n (Time t) = Time (n * t)
 
 -- | Returns the result of division of two 'Time' elements.
-timeDiv :: forall time unit . (time ~ Time unit, KnownRat unit)
-        => time
-        -> time
+timeDiv :: forall (unit :: Rat) . KnownRat unit
+        => Time unit
+        -> Time unit
         -> RatioNat
 timeDiv (Time t1) (Time t2) = t1 / t2

--- a/src/Time/Units.hs
+++ b/src/Time/Units.hs
@@ -31,18 +31,6 @@ module Time.Units
 
        , AllTimes
 
-         -- ** Units
-       , SecondUnit
-       , MillisecondUnit
-       , MicrosecondUnit
-       , NanosecondUnit
-       , PicosecondUnit
-       , MinuteUnit
-       , HourUnit
-       , DayUnit
-       , WeekUnit
-       , FortnightUnit
-
        , UnitName
        , KnownUnitName
        , KnownRatName
@@ -91,43 +79,31 @@ import qualified Control.Concurrent as Concurrent
 import qualified System.CPUTime as CPUTime
 import qualified System.Timeout as Timeout
 
--- | Time unit is represented as type level rational multiplier with kind 'Rat'.
-newtype Time (rat :: Rat) = Time { unTime :: RatioNat }
-    deriving (Eq, Ord, Enum, Real, RealFrac)
-
 ----------------------------------------------------------------------------
 -- Units
 ----------------------------------------------------------------------------
 
-type SecondUnit      = 1 / 1
-type MillisecondUnit = SecondUnit      / 1000
-type MicrosecondUnit = MillisecondUnit / 1000
-type NanosecondUnit  = MicrosecondUnit / 1000
-type PicosecondUnit  = NanosecondUnit  / 1000
+type Second      = 1 / 1
+type Millisecond = Second      / 1000
+type Microsecond = Millisecond / 1000
+type Nanosecond  = Microsecond / 1000
+type Picosecond  = Nanosecond  / 1000
 
-type MinuteUnit      = 60 * SecondUnit
-type HourUnit        = 60 * MinuteUnit
-type DayUnit         = 24 * HourUnit
-type WeekUnit        = 7  * DayUnit
-type FortnightUnit   = 2  * WeekUnit
+type Minute      = 60 * Second
+type Hour        = 60 * Minute
+type Day         = 24 * Hour
+type Week        = 7  * Day
+type Fortnight   = 2  * Week
 
 ----------------------------------------------------------------------------
 -- Time data type
 ----------------------------------------------------------------------------
 
-type Second      = Time SecondUnit
-type Millisecond = Time MillisecondUnit
-type Microsecond = Time MicrosecondUnit
-type Nanosecond  = Time NanosecondUnit
-type Picosecond  = Time PicosecondUnit
+-- | Time unit is represented as type level rational multiplier with kind 'Rat'.
+newtype Time (rat :: Rat) = Time { unTime :: RatioNat }
+    deriving (Eq, Ord, Enum, Real, RealFrac)
 
-type Minute      = Time MinuteUnit
-type Hour        = Time HourUnit
-type Day         = Time DayUnit
-type Week        = Time WeekUnit
-type Fortnight   = Time FortnightUnit
-
--- | Type-level list that consist of all time.
+-- | Type-level list that consist of all times.
 type AllTimes =
   '[ Fortnight, Week, Day, Hour, Minute, Second
    , Millisecond , Microsecond, Nanosecond, Picosecond
@@ -209,80 +185,80 @@ time n = Time (n :% 1)
 -- | Creates 'Second' from given 'Natural'.
 --
 -- >>> sec 42
--- 42s :: Second
-sec :: Natural -> Second
+-- 42s :: Time Second
+sec :: Natural -> Time Second
 sec = time
 {-# INLINE sec #-}
 
 -- | Creates 'Millisecond' from given 'Natural'.
 --
 -- >>> ms 42
--- 42ms :: Millisecond
-ms :: Natural -> Millisecond
+-- 42ms :: Time Millisecond
+ms :: Natural -> Time Millisecond
 ms = time
 {-# INLINE ms #-}
 
 -- | Creates 'Microsecond' from given 'Natural'.
 --
 -- >>> mcs 42
--- 42mcs :: Microsecond
-mcs :: Natural -> Microsecond
+-- 42mcs :: Time Microsecond
+mcs :: Natural -> Time Microsecond
 mcs = time
 {-# INLINE mcs #-}
 
 -- | Creates 'Nanosecond' from given 'Natural'.
 --
 -- >>> ns 42
--- 42ns :: Nanosecond
-ns :: Natural -> Nanosecond
+-- 42ns :: Time Nanosecond
+ns :: Natural -> Time Nanosecond
 ns = time
 {-# INLINE ns #-}
 
 -- | Creates 'Picosecond' from given 'Natural'.
 --
 -- >>> ps 42
--- 42ps :: Picosecond
-ps :: Natural -> Picosecond
+-- 42ps :: Time Picosecond
+ps :: Natural -> Time Picosecond
 ps = time
 {-# INLINE ps #-}
 
 -- | Creates 'Minute' from given 'Natural'.
 --
 -- >>> minute 42
--- 42m :: Minute
-minute :: Natural -> Minute
+-- 42m :: Time Minute
+minute :: Natural -> Time Minute
 minute = time
 {-# INLINE minute #-}
 
 -- | Creates 'Hour' from given 'Natural'.
 --
 -- >>> hour 42
--- 42h :: Hour
-hour :: Natural -> Hour
+-- 42h :: Time Hour
+hour :: Natural -> Time Hour
 hour = time
 {-# INLINE hour #-}
 
 -- | Creates 'Day' from given 'Natural'.
 --
 -- >>> day 42
--- 42d :: Day
-day :: Natural -> Day
+-- 42d :: Time Day
+day :: Natural -> Time Day
 day = time
 {-# INLINE day #-}
 
 -- | Creates 'Week' from given 'Natural'.
 --
 -- >>> sec 42
--- 42w :: Week
-week :: Natural -> Week
+-- 42w :: Time Week
+week :: Natural -> Time Week
 week = time
 {-# INLINE week #-}
 
 -- | Creates 'Fortnight' from given 'Natural'.
 --
 -- >>> fortnight 42
--- 42fn :: Fortnight
-fortnight :: Natural -> Fortnight
+-- 42fn :: Time Fortnight
+fortnight :: Natural -> Time Fortnight
 fortnight = time
 {-# INLINE fortnight #-}
 
@@ -291,14 +267,14 @@ fortnight = time
 >>> floorUnit @Day (Time $ 5 % 2)
 2d
 
->>> floorUnit (Time @SecondUnit $ 2 % 3)
+>>> floorUnit (Time @Second $ 2 % 3)
 0s
 
 >>> floorUnit $ ps 42
 42ps
 
 -}
-floorUnit :: forall time unit . (time ~ Time unit) => time -> time
+floorUnit :: forall (unit :: Rat) . Time unit -> Time unit
 floorUnit = time . floor
 
 -- | Sums times of different units.
@@ -306,10 +282,10 @@ floorUnit = time . floor
 -- >>> minute 1 +: sec 1
 -- 61s
 --
-(+:) :: forall timeB timeA b a . (timeA ~ Time a, timeB ~ Time b, KnownDivRat a b)
-     => timeA
-     -> timeB
-     -> timeB
+(+:) :: forall (unitResult :: Rat) (unitLeft :: Rat) . KnownDivRat unitLeft unitResult
+     => Time unitLeft
+     -> Time unitResult
+     -> Time unitResult
 t1 +: t2 = toUnit t1 + t2
 {-# INLINE (+:) #-}
 
@@ -319,26 +295,25 @@ t1 +: t2 = toUnit t1 + t2
 
 {- | Converts from one time unit to another time unit.
 
->>> toUnit @Hour (120 :: Minute)
+>>> toUnit @Hour (120 :: Time Minute)
 2h
 
 >>> toUnit @Second (ms 7)
 7/1000s
 
->>> toUnit @Week (Time @DayUnit 45)
+>>> toUnit @Week (Time @Day 45)
 45/7w
 
 >>> toUnit @Second @Minute 3
 180s
 
->>> toUnit (day 42000000) :: Second
+>>> toUnit (day 42000000) :: Time Second
 3628800000000s
 
 -}
-toUnit :: forall timeTo timeFrom (unitTo :: Rat) (unitFrom :: Rat) .
-          (timeTo ~ Time unitTo, timeFrom ~ Time unitFrom, KnownDivRat unitFrom unitTo)
-       => timeFrom
-       -> timeTo
+toUnit :: forall (unitTo :: Rat) (unitFrom :: Rat) . KnownDivRat unitFrom unitTo
+       => Time unitFrom
+       -> Time unitTo
 toUnit Time{..} = Time $ unTime * ratVal @(unitFrom / unitTo)
 {-# INLINE toUnit #-}
 
@@ -347,12 +322,12 @@ toUnit Time{..} = Time $ unTime * ratVal @(unitFrom / unitTo)
 
 
 >>> threadDelay $ sec 2
->>> threadDelay (2 :: Second)
+>>> threadDelay (2 :: Time Second)
 >>> threadDelay @Second 2
 
 -}
-threadDelay :: forall time unit m . (time ~ Time unit, KnownDivRat unit MicrosecondUnit, MonadIO m)
-            => time
+threadDelay :: forall (unit :: Rat) m . (KnownDivRat unit Microsecond, MonadIO m)
+            => Time unit
             -> m ()
 threadDelay = liftIO . Concurrent.threadDelay . floor . toUnit @Microsecond
 {-# INLINE threadDelay #-}
@@ -363,8 +338,8 @@ threadDelay = liftIO . Concurrent.threadDelay . floor . toUnit @Microsecond
 --
 -- >>> getCPUTime @Second
 -- 1064046949/1000000000s
-getCPUTime :: forall time unit m . (time ~ Time unit, KnownDivRat PicosecondUnit unit, MonadIO m)
-           => m time
+getCPUTime :: forall (unit :: Rat) m . (KnownDivRat Picosecond unit, MonadIO m)
+           => m (Time unit)
 getCPUTime = toUnit . ps . fromInteger <$> liftIO CPUTime.getCPUTime
 {-# INLINE getCPUTime #-}
 
@@ -382,8 +357,8 @@ Nothing
 HellNothing
 
 -}
-timeout :: forall time unit m a . (time ~ Time unit, MonadIO m, KnownDivRat unit MicrosecondUnit)
-        => time        -- ^ time
+timeout :: forall (unit :: Rat) m a . (MonadIO m, KnownDivRat unit Microsecond)
+        => Time unit   -- ^ time
         -> IO a        -- ^ 'IO' action
         -> m (Maybe a) -- ^ returns 'Nothing' if no result is available within the given time
 timeout t = liftIO . Timeout.timeout (floor $ toUnit @Microsecond t)

--- a/test/Test/Time/Property.hs
+++ b/test/Test/Time/Property.hs
@@ -16,9 +16,9 @@ import Hedgehog (MonadGen, MonadTest, Property, PropertyT, forAll, property, (==
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testProperty)
 
-import Time (DayUnit, FortnightUnit, HourUnit, KnownRat, KnownRatName, MicrosecondUnit,
-             MillisecondUnit, MinuteUnit, NanosecondUnit, PicosecondUnit, Rat, RatioNat, SecondUnit,
-             Time (..), WeekUnit, toUnit, withRuntimeDivRat)
+import Time (Day, Fortnight, Hour, KnownRat, KnownRatName, Microsecond,
+             Millisecond, Minute, Nanosecond, Picosecond, Rat, RatioNat, Second,
+             Time (..), Week, toUnit, withRuntimeDivRat)
 
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -42,16 +42,16 @@ instance Show AnyTime where
 -- | Returns random 'AnyTime'.
 unitChooser :: (MonadGen m) => RatioNat -> m AnyTime
 unitChooser t = Gen.element
-    [ MkAnyTime (Time @SecondUnit      t)
-    , MkAnyTime (Time @MillisecondUnit t)
-    , MkAnyTime (Time @MicrosecondUnit t)
-    , MkAnyTime (Time @NanosecondUnit  t)
-    , MkAnyTime (Time @PicosecondUnit  t)
-    , MkAnyTime (Time @MinuteUnit      t)
-    , MkAnyTime (Time @HourUnit        t)
-    , MkAnyTime (Time @DayUnit         t)
-    , MkAnyTime (Time @WeekUnit        t)
-    , MkAnyTime (Time @FortnightUnit   t)
+    [ MkAnyTime (Time @Second      t)
+    , MkAnyTime (Time @Millisecond t)
+    , MkAnyTime (Time @Microsecond t)
+    , MkAnyTime (Time @Nanosecond  t)
+    , MkAnyTime (Time @Picosecond  t)
+    , MkAnyTime (Time @Minute      t)
+    , MkAnyTime (Time @Hour        t)
+    , MkAnyTime (Time @Day         t)
+    , MkAnyTime (Time @Week        t)
+    , MkAnyTime (Time @Fortnight   t)
     ]
 
 -- | Verifier for 'AnyTime' @read . show = id@.
@@ -69,7 +69,7 @@ verifyToUnit (MkAnyTime t1) (MkAnyTime t2) = checkToUnit t1 t2
                 -> m ()
     checkToUnit t _ = withRuntimeDivRat @unitTo @unitFrom
                     $ withRuntimeDivRat @unitFrom @unitTo
-                    $ toUnit (toUnit @(Time unitTo) t) === t
+                    $ toUnit (toUnit @unitTo t) === t
 
 -- | Generates random natural number up to 10^20.
 -- it receives the lower bound so that it wouldn't be possible

--- a/test/Test/Time/TypeSpec.hs
+++ b/test/Test/Time/TypeSpec.hs
@@ -10,8 +10,8 @@ import Test.TypeSpec
 import Test.TypeSpecCrazy
 
 import Time.Rational ((:%), type (/), Gcd, Normalize)
-import Time.Units (DayUnit, FortnightUnit, HourUnit, MicrosecondUnit, MillisecondUnit, MinuteUnit,
-                   NanosecondUnit, PicosecondUnit, SecondUnit, UnitName, WeekUnit)
+import Time.Units (Day, Fortnight, Hour, Microsecond, Millisecond, Minute,
+                   Nanosecond, Picosecond, Second, UnitName, Week)
 
 runTypeSpecTests :: IO ()
 runTypeSpecTests = do
@@ -91,21 +91,21 @@ typeSpec_UnitCalculation ::
 
     "Lower"
     ~~~~~~~~~~~~
-         It "Second      = 1 % 1"             (     SecondUnit `Is` (1 :% 1))
-     -*- It "Millisecond = 1 % 1000"          (MillisecondUnit `Is` (1 :% 1000))
-     -*- It "Microsecond = 1 % 1000000"       (MicrosecondUnit `Is` (1 :% 1000000))
-     -*- It "Nanosecond  = 1 % 1000000000"    ( NanosecondUnit `Is` (1 :% 1000000000))
-     -*- It "Picosecond  = 1 % 1000000000000" ( PicosecondUnit `Is` (1 :% 1000000000000))
+         It "Second      = 1 % 1"             (     Second `Is` (1 :% 1))
+     -*- It "Millisecond = 1 % 1000"          (Millisecond `Is` (1 :% 1000))
+     -*- It "Microsecond = 1 % 1000000"       (Microsecond `Is` (1 :% 1000000))
+     -*- It "Nanosecond  = 1 % 1000000000"    ( Nanosecond `Is` (1 :% 1000000000))
+     -*- It "Picosecond  = 1 % 1000000000000" ( Picosecond `Is` (1 :% 1000000000000))
 
  -/-
 
     "Bigger"
     ~~~~~~~~~~~~
-         It "Minute    = 60 % 1"      (MinuteUnit    `Is` (60 :% 1))
-     -*- It "Hour      = 3600 % 1"    (HourUnit      `Is` (3600 :% 1))
-     -*- It "Day       = 86400 % 1"   (DayUnit       `Is` (86400 :% 1))
-     -*- It "Week      = 604800 % 1"  (WeekUnit      `Is` (604800 :% 1))
-     -*- It "Fortnight = 1209600 % 1" (FortnightUnit `Is` (1209600 :% 1))
+         It "Minute    = 60 % 1"      (Minute    `Is` (60 :% 1))
+     -*- It "Hour      = 3600 % 1"    (Hour      `Is` (3600 :% 1))
+     -*- It "Day       = 86400 % 1"   (Day       `Is` (86400 :% 1))
+     -*- It "Week      = 604800 % 1"  (Week      `Is` (604800 :% 1))
+     -*- It "Fortnight = 1209600 % 1" (Fortnight `Is` (1209600 :% 1))
 
 typeSpec_UnitCalculation = Valid
 
@@ -116,20 +116,20 @@ typeSpec_UnitNames ::
 
     "Lower"
     ~~~~~~~~~~~~
-         It "UnitName SecondUnit      = 's'"   (UnitName SecondUnit      `Is` "s")
-     -*- It "UnitName MillisecondUnit = 'ms'"  (UnitName MillisecondUnit `Is` "ms")
-     -*- It "UnitName MicrosecondUnit = 'mcs'" (UnitName MicrosecondUnit `Is` "mcs")
-     -*- It "UnitName NanosecondUnit  = 'ns'"  (UnitName NanosecondUnit  `Is` "ns")
-     -*- It "UnitName PicosecondUnit  = 'ps'"  (UnitName PicosecondUnit  `Is` "ps")
+         It "UnitName Second      = 's'"   (UnitName Second      `Is` "s")
+     -*- It "UnitName Millisecond = 'ms'"  (UnitName Millisecond `Is` "ms")
+     -*- It "UnitName Microsecond = 'mcs'" (UnitName Microsecond `Is` "mcs")
+     -*- It "UnitName Nanosecond  = 'ns'"  (UnitName Nanosecond  `Is` "ns")
+     -*- It "UnitName Picosecond  = 'ps'"  (UnitName Picosecond  `Is` "ps")
 
  -/-
 
     "Bigger"
     ~~~~~~~~~~~~
-         It "UnitName MinuteUnit    = 'm'"  (UnitName MinuteUnit    `Is` "m")
-     -*- It "UnitName HourUnit      = 'h'"  (UnitName HourUnit      `Is` "h")
-     -*- It "UnitName DayUnit       = 'd'"  (UnitName DayUnit       `Is` "d")
-     -*- It "UnitName WeekUnit      = 'w'"  (UnitName WeekUnit      `Is` "w")
-     -*- It "UnitName FortnightUnit = 'fn'" (UnitName FortnightUnit `Is` "fn")
+         It "UnitName Minute    = 'm'"  (UnitName Minute    `Is` "m")
+     -*- It "UnitName Hour      = 'h'"  (UnitName Hour      `Is` "h")
+     -*- It "UnitName Day       = 'd'"  (UnitName Day       `Is` "d")
+     -*- It "UnitName Week      = 'w'"  (UnitName Week      `Is` "w")
+     -*- It "UnitName Fortnight = 'fn'" (UnitName Fortnight `Is` "fn")
 
 typeSpec_UnitNames = Valid

--- a/test/Test/Time/Units.hs
+++ b/test/Test/Time/Units.hs
@@ -12,9 +12,9 @@ import GHC.Real (Ratio ((:%)))
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (Spec, anyException, describe, it, shouldBe, shouldThrow, testSpec)
 
-import Time (Day, Hour, HourUnit, Microsecond, Millisecond, Minute, MinuteUnit, Picosecond, Second,
-             SecondUnit, Time (..), Week, day, floorUnit, fortnight, hour, mcs, minute, ms, ns, ps,
-             sec, seriesF, toUnit, unitsF, week, (+:))
+import Time (Day, Hour, Microsecond, Millisecond, Minute, Picosecond, Second, Time (..), Week, day,
+             floorUnit, fortnight, hour, mcs, minute, ms, ns, ps, sec, seriesF, toUnit, unitsF,
+             week, (+:))
 
 unitsTestTree :: IO TestTree
 unitsTestTree = testSpec "Units" spec_Units
@@ -38,24 +38,24 @@ spec_Units = do
             toUnit @Picosecond (ns 1) `shouldBe` 1000
     describe "Read Time Test" $ do
         it "parses '42s' as 42 seconds" $
-            read @Second "42s" `shouldBe` 42
+            read @(Time Second) "42s" `shouldBe` 42
         it "fails when '42mm' is expected as seconds" $
-            evaluate (read @Second "42mm") `shouldThrow` anyException
+            evaluate (read @(Time Second) "42mm") `shouldThrow` anyException
         it "parses '7/2s' as 7/2 seconds" $
-            read @Second "7/2s" `shouldBe` Time (7 :% 2)
+            read @(Time Second) "7/2s" `shouldBe` Time (7 :% 2)
         it "fails when '-4s' is expected as seconds" $
-            evaluate (read @Second "-4s") `shouldThrow` anyException
+            evaluate (read @(Time Second) "-4s") `shouldThrow` anyException
         it "parses '14/2h' as 7 hours" $
-            read @Hour "14/2h" `shouldBe` 7
+            read @(Time Hour) "14/2h" `shouldBe` 7
         it "fails when '14/2h' expected as 7 seconds" $
-            evaluate (read @Second "14/2h") `shouldThrow` anyException
+            evaluate (read @(Time Second) "14/2h") `shouldThrow` anyException
         it "parses big number to big number" $
-            read @Microsecond ('1' : replicate 20 '0' ++ "mcs") `shouldBe` 100000000000000000000
+            read @(Time Microsecond) ('1' : replicate 20 '0' ++ "mcs") `shouldBe` 100000000000000000000
         it "fails when '4ms' expected as 4 seconds" $
-            evaluate (read @Second "4ms") `shouldThrow` anyException
+            evaluate (read @(Time Second) "4ms") `shouldThrow` anyException
     describe "Floor tests" $ do
         it "returns 0s when floor < 1 second" $
-            floorUnit (Time @SecondUnit $ 2 :% 3) `shouldBe` 0
+            floorUnit (Time @Second $ 2 :% 3) `shouldBe` 0
         it "returns 2d when floor 2.5 days" $
             floorUnit @Day (Time $ 5 :% 2) `shouldBe` 2
         it "returns 42ps when floor integer" $
@@ -68,7 +68,7 @@ spec_Units = do
         it "3601 sec should be formatted without middle-zeros" $
             seriesF @'[Hour, Minute, Second] (sec 3601) `shouldBe` "1h1s"
         it "works on rational nums" $
-            seriesF @'[Hour, Second, Millisecond] (Time @MinuteUnit $ 3 :% 2) `shouldBe` "90s"
+            seriesF @'[Hour, Second, Millisecond] (Time @Minute $ 3 :% 2) `shouldBe` "90s"
         it "works without minutes formatting" $
             seriesF @'[Day, Minute, Second] (minute 4000) `shouldBe` "2d1120m"
 
@@ -77,7 +77,7 @@ spec_Units = do
         it "42 fortnights should be formatted like 42fn" $
             unitsF (fortnight 42) `shouldBe` "42fn"
         it "empty when receive zero time" $
-            unitsF (Time @HourUnit 0) `shouldBe` ""
+            unitsF (Time @Hour 0) `shouldBe` ""
         it "sums all time units" $
             unitsF (  fortnight 1 +: week 1 +: day 1 +: hour 1 +: minute 1
                    +: sec 1 +: ms 1 +: mcs 1 +: ns 1 +: ps 1


### PR DESCRIPTION
Resolves #47 .
Renaming is performed. In most places functions got simpler. But several drawbacks noticed:

1. You can't create time using `5 :: Second` way. Now you can use only `5 :: Time Second`.
2. You can't use `read` like `read @Second`. Now only `read @(Time Second)`.