### PR TITLE
Show/Read instances for Time now use mixed fractions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The change log is available [on GitHub][2].
 0.0.1
 =====
 
+* [#61](https://github.com/serokell/o-clock/issues/61):
+  Change `Show` and `Read` instances for `Time` to use
+  mixed fractions.
 * [#72](https://github.com/serokell/o-clock/issues/72):
   Move `+:+` and `-:-` to `TimeStamp` module.
   Make operators `*:*` and `/:/` for `timeMul` and `timeDiv`.

--- a/test/Test/Time/Units.hs
+++ b/test/Test/Time/Units.hs
@@ -45,6 +45,14 @@ spec_Units = do
             read @(Time Second) "7/2s" `shouldBe` Time (7 :% 2)
         it "fails when '-4s' is expected as seconds" $
             evaluate (read @(Time Second) "-4s") `shouldThrow` anyException
+        it "parses '25+5/7s' as 180/7 seconds" $
+            read @(Time Second) "25+5/7s" `shouldBe` Time (180 :% 7)
+        it "fails when '3+2s' is expected as seconds" $
+            evaluate (read @(Time Second) "3+2s") `shouldThrow` anyException
+        it "fails when '+3s' is expected as seconds" $
+            evaluate (read @(Time Second) "+3s") `shouldThrow` anyException
+        it "fails when '/3s' is expected as seconds" $
+            evaluate (read @(Time Second) "/3s") `shouldThrow` anyException
         it "parses '14/2h' as 7 hours" $
             read @(Time Hour) "14/2h" `shouldBe` 7
         it "fails when '14/2h' expected as 7 seconds" $


### PR DESCRIPTION
The Show and Read instances for Time now support mixed fractions:
`show` always outputs a mixed fraction, and `read` can read either
an improper fraction (the previous functionality) or a mixed
fraction.

The Show instance now has `showsPrec` explicitly implemented
instead of `show` as precedence could potentially matter with the
'+' in the middle.  Parentheses are added when the surrounding
precedence is greater than 6, the precedence of '+'.  For example,
3 * (7+2/5s).  This should not affect `seriesF` as that uses show,
and so a precdence of 0.

Resolves #61 