### PR TITLE
Update CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: MPL-2.0
 [![Hackage](https://img.shields.io/hackage/v/o-clock.svg)](https://hackage.haskell.org/package/o-clock)
 [![Stackage](http://stackage.org/package/o-clock/badge/lts)](http://stackage.org/lts/package/o-clock)
 [![Stackage Nightly](http://stackage.org/package/o-clock/badge/nightly)](http://stackage.org/nightly/package/o-clock)
-[![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/serokell/o-clock/blob/master/LICENSE)
+[![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://github.com/serokell/o-clock/blob/master/LICENSE)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ SPDX-License-Identifier: MPL-2.0
 
 # O'Clock
 
+[![GitHub CI](https://github.com/serokell/o-clock/workflows/CI/badge.svg)](https://github.com/serokell/o-clock/actions)
 [![Hackage](https://img.shields.io/hackage/v/o-clock.svg)](https://hackage.haskell.org/package/o-clock)
-[![Build status](https://travis-ci.org/serokell/o-clock.svg?branch=master)](https://travis-ci.org/serokell/o-clock)
 [![Stackage](http://stackage.org/package/o-clock/badge/lts)](http://stackage.org/lts/package/o-clock)
 [![Stackage Nightly](http://stackage.org/package/o-clock/badge/nightly)](http://stackage.org/nightly/package/o-clock)
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/serokell/o-clock/blob/master/LICENSE)

--- a/o-clock.cabal
+++ b/o-clock.cabal
@@ -71,7 +71,7 @@ test-suite o-clock-test
   build-depends:       base            >= 4.9  && < 5
                      , o-clock
                      , hedgehog       >= 0.6 && < 1.1
-                     , tasty          >= 0.12 && < 1.3
+                     , tasty          >= 0.12 && < 1.4
                      , tasty-hedgehog >= 0.1 && < 1.1
                      , tasty-hspec    ^>= 1.1.3
                      , type-spec      >= 0.3.0.1 && < 0.5
@@ -91,7 +91,7 @@ test-suite o-clock-doctest
 
   build-tool-depends:  doctest:doctest
   build-depends:       base    >= 4.10 && < 5
-                     , doctest ^>= 0.16
+                     , doctest >= 0.16 && < 0.18
                      , Glob    >= 0.9 && < 0.11
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010


### PR DESCRIPTION
Problem: we are using GitHub CI now, but the badge is old (Travis).
Solution: update the badge.