### PR TITLE
Use a different setup-haskell action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1
+    - uses: haskell/actions/setup@v1.1
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
@@ -102,7 +102,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1
+    - uses: haskell/actions/setup@v1.1
       name: Setup Haskell Stack
       with:
         ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
Problem: https://github.com/actions/setup-haskell is archived and not
maintained, but we are using it.

Solution: use https://github.com/haskell/actions instead.