### PR TITLE
Drop tasty-hspec dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Change log
 o'clock uses [PVP Versioning][1].
 The change log is available [on GitHub][2].
 
+1.2.1
+=====
+
+* [#121](https://github.com/serokell/o-clock/pull/121):
+  + Remove `tasty-hspec` dependency from tests.
+
 1.2.0.1
 =======
 

--- a/o-clock.cabal
+++ b/o-clock.cabal
@@ -71,9 +71,10 @@ test-suite o-clock-test
   build-depends:       base            >= 4.9  && < 5
                      , o-clock
                      , hedgehog       >= 0.6 && < 1.1
+                     , hspec-expectations ^>= 0.8
                      , tasty          >= 0.12 && < 1.5
                      , tasty-hedgehog >= 0.1 && < 1.2
-                     , tasty-hspec    ^>= 1.1.3
+                     , tasty-hunit-compat ^>= 0.2
                      , type-spec      >= 0.3.0.1 && < 0.5
 
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N

--- a/o-clock.cabal
+++ b/o-clock.cabal
@@ -3,7 +3,7 @@
 -- SPDX-License-Identifier: MPL-2.0
 
 name:                o-clock
-version:             1.2.0.1
+version:             1.2.1
 synopsis:            Type-safe time library.
 description:         See README.md for details.
 homepage:            https://github.com/serokell/o-clock

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -15,12 +15,7 @@ main :: IO ()
 main = do
     -- type specs
     runTypeSpecTests
-    -- Units tests with tasty:
-    -- • toUnit tests
-    -- • read tests
-    unitTests <- unitsTestTree
-    -- Timestamp tests
-    tsTests   <- timeStampTestTree
 
-    let allTests = testGroup "O'Clock" $ [unitTests, tsTests] ++ hedgehogTestTrees
+    let allTests = testGroup "O'Clock" $
+            [unitsTestTree, timeStampTestTree] ++ hedgehogTestTrees
     defaultMain allTests

--- a/test/Test/Time/Timestamp.hs
+++ b/test/Test/Time/Timestamp.hs
@@ -12,32 +12,35 @@ module Test.Time.Timestamp
        ) where
 
 import Control.Exception (evaluate)
-import Test.Tasty (TestTree)
-import Test.Tasty.Hspec (Spec, anyException, describe, it, shouldBe, shouldThrow, testSpec)
+import Test.Hspec.Expectations (anyException, shouldBe, shouldThrow)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
 
 import Time (Minute, Second, Time (..), Timestamp (..), Week, hour, ms, ps, sec, timeAdd, timeDiff,
              timeDiv, timeMul)
 
-timeStampTestTree :: IO TestTree
-timeStampTestTree = testSpec "Timestamp and time operations" spec_Timestamp
-
-
-spec_Timestamp :: Spec
-spec_Timestamp = do
-    describe "TimeDiff" $ do
-        it "1 is less than 5, diff is 4 seconds" $
+timeStampTestTree :: TestTree
+timeStampTestTree = testGroup "Timestamp and time operations"
+    [ testGroup "timeDiff"
+        [ testCase "1 is less than 5, diff is 4 seconds" $
             timeDiff @Second (Timestamp 1) (Timestamp 5) `shouldBe` (LT, Time 4)
-        it "100 is greater that 40, diff is 60 sec == 1 min" $
+        , testCase "100 is greater that 40, diff is 60 sec == 1 min" $
             timeDiff @Minute (Timestamp 100) (Timestamp 40) `shouldBe` (GT, Time 1)
-        it "42 is equal to 42, diff is 0 Weeks" $
+        , testCase "42 is equal to 42, diff is 0 Weeks" $
             timeDiff @Week (Timestamp 42) (Timestamp 42) `shouldBe` (EQ, Time 0)
-        it "3 hours offset 7 is 10"  $
-            timeAdd (hour 3) (Timestamp 7) `shouldBe` (Timestamp 10807)
-        it "twice 21 mcs is 42 mcs"  $
+        ]
+    , testGroup "timeAdd"
+        [ testCase "3 hours offset 7 is 10" $
+            timeAdd (hour 3) (Timestamp 7) `shouldBe` Timestamp 10807
+        ]
+    , testGroup "timeMul"
+        [ testCase "twice 21 mcs is 42 mcs" $
             timeMul 2 (ms 21) `shouldBe` ms 42
-        it "zero x 42 s is zero"  $
-            timeMul 0 (sec 42) `shouldBe` sec 0
-        it "84 picoseconds divide by 2 is 42"  $
+        ]
+    , testGroup "timeDiv"
+        [ testCase "84 picoseconds divide by 2 is 42" $
             timeDiv (ps 84) (ps 2) `shouldBe` 42
-        it "fails when trying to divide by zero"  $
+        , testCase "fails when trying to divide by zero" $
             evaluate (timeDiv (sec 42) $ sec 0) `shouldThrow` anyException
+        ]
+    ]

--- a/test/Test/Time/Units.hs
+++ b/test/Test/Time/Units.hs
@@ -13,83 +13,89 @@ module Test.Time.Units
 
 import Control.Exception (evaluate)
 import GHC.Real (Ratio ((:%)))
-import Test.Tasty (TestTree)
-import Test.Tasty.Hspec (Spec, anyException, describe, it, shouldBe, shouldThrow, testSpec)
+import Test.Hspec.Expectations (anyException, shouldBe, shouldThrow)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
 
 import Time (Day, Hour, Millisecond, Minute, Second, Time (..), Week, day, floorUnit, fortnight,
              hour, mcs, minute, ms, ns, ps, sec, seriesF, toUnit, unitsF, week, (+:+))
 
-unitsTestTree :: IO TestTree
-unitsTestTree = testSpec "Units" spec_Units
+unitsTestTree :: TestTree
+unitsTestTree = testGroup "Units" unitsTests
 
-spec_Units :: Spec
-spec_Units = do
-    describe "Unit Conversion Test" $ do
-        it "11 seconds is 11000 milliseconds" $
+unitsTests :: [TestTree]
+unitsTests =
+    [ testGroup "Unit Conversion Test"
+        [ testCase "11 seconds is 11000 milliseconds" $
             toUnit (sec 11) `shouldBe` ms 11000
-        it "5000 milliseconds is 5 seconds" $
+        , testCase "5000 milliseconds is 5 seconds" $
             toUnit (ms 5000) `shouldBe` sec 5
-        it "3 seconds is 3000000 microseconds" $
+        , testCase "3 seconds is 3000000 microseconds" $
             toUnit (sec 3) `shouldBe` mcs 3000000
-        it "3 microseconds is 3/1000000 seconds" $
+        , testCase "3 microseconds is 3/1000000 seconds" $
             toUnit @Second (mcs 3) `shouldBe` Time (3 :% 1000000)
-        it "7 days is 1 week" $
+        , testCase "7 days is 1 week" $
             toUnit (day 7) `shouldBe` week 1
-        it "2 fornights is 28 days" $
+        , testCase "2 fornights is 28 days" $
             toUnit (fortnight 2) `shouldBe` day 28
-        it "1 nanosecond is 1000 picoseconds" $
+        , testCase "1 nanosecond is 1000 picoseconds" $
             toUnit (ns 1) `shouldBe` ps 1000
-    describe "Read Time Test" $ do
-        it "parses '42s' as 42 seconds" $
+        ]
+    , testGroup "Read Time Test"
+        [ testCase "parses '42s' as 42 seconds" $
             read "42s" `shouldBe` sec 42
-        it "fails when '42mm' is expected as seconds" $
+        , testCase "fails when '42mm' is expected as seconds" $
             evaluate (read @(Time Second) "42mm") `shouldThrow` anyException
-        it "parses '7/2s' as 7/2 seconds" $
+        , testCase "parses '7/2s' as 7/2 seconds" $
             read @(Time Second) "7/2s" `shouldBe` Time (7 :% 2)
-        it "fails when '-4s' is expected as seconds" $
+        , testCase "fails when '-4s' is expected as seconds" $
             evaluate (read @(Time Second) "-4s") `shouldThrow` anyException
-        it "parses '25+5/7s' as 180/7 seconds" $
+        , testCase "parses '25+5/7s' as 180/7 seconds" $
             read @(Time Second) "25+5/7s" `shouldBe` Time (180 :% 7)
-        it "fails when '3+2s' is expected as seconds" $
+        , testCase "fails when '3+2s' is expected as seconds" $
             evaluate (read @(Time Second) "3+2s") `shouldThrow` anyException
-        it "fails when '+3s' is expected as seconds" $
+        , testCase "fails when '+3s' is expected as seconds" $
             evaluate (read @(Time Second) "+3s") `shouldThrow` anyException
-        it "fails when '/3s' is expected as seconds" $
+        , testCase "fails when '/3s' is expected as seconds" $
             evaluate (read @(Time Second) "/3s") `shouldThrow` anyException
-        it "parses '14/2h' as 7 hours" $
+        , testCase "parses '14/2h' as 7 hours" $
             read "14/2h" `shouldBe` hour 7
-        it "fails when '14/2h' expected as 7 seconds" $
+        , testCase "fails when '14/2h' expected as 7 seconds" $
             evaluate (read @(Time Second) "14/2h") `shouldThrow` anyException
-        it "parses big number to big number" $
+        , testCase "parses big number to big number" $
             read ('1' : replicate 20 '0' ++ "mcs") `shouldBe` mcs (10 ^ (20 :: Int))
-        it "fails when '4ms' expected as 4 seconds" $
+        , testCase "fails when '4ms' expected as 4 seconds" $
             evaluate (read @(Time Second) "4ms") `shouldThrow` anyException
-    describe "Floor tests" $ do
-        it "returns 0s when floor < 1 second" $
+        ]
+    , testGroup "Floor tests"
+        [ testCase "returns 0s when floor < 1 second" $
             floorUnit (Time @Second $ 2 :% 3) `shouldBe` sec 0
-        it "returns 2d when floor 2.5 days" $
+        , testCase "returns 2d when floor 2.5 days" $
             floorUnit (Time $ 5 :% 2) `shouldBe` day 2
-        it "returns 42ps when floor integer" $
+        , testCase "returns 42ps when floor integer" $
             floorUnit (ps 42) `shouldBe` ps 42
-    describe "Formatting tests" $ do
-        it "4000 minutes should be formatted without ending-zeros" $
+        ]
+    , testGroup "Formatting tests"
+        [ testCase "4000 minutes should be formatted without ending-zeros" $
             seriesF @'[Day, Hour, Minute, Second] (minute 4000) `shouldBe` "2d18h40m"
-        it "4000 minutes should be formatted without beginning-zeros" $
+        , testCase "4000 minutes should be formatted without beginning-zeros" $
             seriesF @'[Week, Day, Hour, Minute] (minute 4000) `shouldBe` "2d18h40m"
-        it "3601 sec should be formatted without middle-zeros" $
+        , testCase "3601 sec should be formatted without middle-zeros" $
             seriesF @'[Hour, Minute, Second] (sec 3601) `shouldBe` "1h1s"
-        it "works on rational nums" $
+        , testCase "works on rational nums" $
             seriesF @'[Hour, Second, Millisecond] (Time @Minute $ 3 :% 2) `shouldBe` "90s"
-        it "works without minutes formatting" $
+        , testCase "works without minutes formatting" $
             seriesF @'[Day, Minute, Second] (minute 4000) `shouldBe` "2d1120m"
 
-        it "4000 minutes should be formatted like 2d18h40m" $
+        , testCase "4000 minutes should be formatted like 2d18h40m" $
             unitsF (minute 4000) `shouldBe` "2d18h40m"
-        it "42 fortnights should be formatted like 42fn" $
+        , testCase "42 fortnights should be formatted like 42fn" $
             unitsF (fortnight 42) `shouldBe` "42fn"
-        it "the first zero time unit when receive zero time" $
+        , testCase "the first zero time unit when receive zero time" $
             unitsF (Time @Hour 0) `shouldBe` "0fn"
-        it "sums all time units" $
+        , testCase "sums all time units" $
             unitsF (  fortnight 1 +:+ week 1 +:+ day 1 +:+ hour 1 +:+ minute 1
                   +:+ sec 1 +:+ ms 1 +:+ mcs 1 +:+ ns 1 +:+ ps 1
                    ) `shouldBe` "1fn1w1d1h1m1s1ms1mcs1ns1ps"
+        ]
+    ]


### PR DESCRIPTION
Problem: we write some tests using `hspec` and then convert them to
tasty trees using `tasty-hspec`. This conversion is not necessary,
but causes extra dependencies to be added to one test-suite.
Moreover, sometimes it's not 100% precise.

Solution: remove this dependency and group tests into trees ourselves.
It doesn't add any overhead, we are just using a slightly different
syntax.
We don't transitively depend on `hspec` anymore, but we need
`hspec-expectations` as a replacement to use things like `shouldThrow`.

Resolves #120