### PR TITLE
[#126] Add the ceiling counterparts to the floor functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Unreleased
   + Deprecate `toNum`: may cause accidental flooring.
   + Add the `toFractional` function to avoid the accidental flooring.
   + Change the order of the type variables in the definition of `floorRat` so that the target type comes first.
+* [#131](https://github.com/serokell/o-clock/pull/131)
+  + Add `ceilingRat` and `ceilingUnit`.
 
 1.2.1.1
 =====

--- a/src/Time/Units.hs
+++ b/src/Time/Units.hs
@@ -43,6 +43,8 @@ module Time.Units
        , time
        , floorUnit
        , floorRat
+       , ceilingUnit
+       , ceilingRat
        , toNum
        , toFractional
 
@@ -318,6 +320,25 @@ floorRat = floor . unTime
 -}
 floorUnit :: forall (unit :: Rat) . Time unit -> Time unit
 floorUnit = time . fromIntegral @Natural . floorRat
+
+-- | Returns the smallest integer greater than or equal to the given 'Time'.
+ceilingRat :: forall b (unit :: Rat) . (Integral b) => Time unit -> b
+ceilingRat = ceiling . unTime
+
+{- | Similar to 'ceiling', but works with 'Time' units.
+
+>>> ceilingUnit @Day (Time $ 5 % 2)
+3d
+
+>>> ceilingUnit (Time @Second $ 2 % 3)
+1s
+
+>>> ceilingUnit $ ps 42
+42ps
+
+-}
+ceilingUnit :: forall (unit :: Rat) . Time unit -> Time unit
+ceilingUnit = time . fromIntegral @Natural . ceilingRat
 
 {- | Convert time to the 'Num' in given units.
 

--- a/test/Test/Time/Units.hs
+++ b/test/Test/Time/Units.hs
@@ -17,9 +17,10 @@ import Test.Hspec.Expectations (anyException, shouldBe, shouldThrow)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
 
-import Time (Day, Hour, Millisecond, Minute, Second, Time (..), Week, day, floorUnit, fortnight,
-             hour, mcs, minute, ms, ns, ps, sec, seriesF, toUnit, toFractional, unitsF, week,
-             (+:+))
+
+import Time (Day, Hour, Millisecond, Minute, Second, Time (..), Week, day, floorUnit, ceilingUnit,
+             fortnight, hour, mcs, minute, ms, ns, ps, sec, seriesF, toUnit, toFractional, unitsF,
+             week, (+:+))
 
 unitsTestTree :: TestTree
 unitsTestTree = testGroup "Units" unitsTests
@@ -75,6 +76,14 @@ unitsTests =
             floorUnit (Time $ 5 :% 2) `shouldBe` day 2
         , testCase "returns 42ps when floor integer" $
             floorUnit (ps 42) `shouldBe` ps 42
+        ]
+    , testGroup "Ceiling tests"
+        [ testCase "returns 1s, given 2/3 seconds" $
+            ceilingUnit (Time @Second $ 2 :% 3) `shouldBe` sec 1
+        , testCase "returns 3d, given 2+1/2 days" $
+            ceilingUnit (Time $ 5 :% 2) `shouldBe` day 3
+        , testCase "returns 42ps, given exactly 42 picoseconds" $
+            ceilingUnit (ps 42) `shouldBe` ps 42
         ]
     , testGroup "Conversion to Fractional values"
         [ testCase "The 'Rational' representation of (hour $ 1 % 8) should be equal to 1 % 8" $


### PR DESCRIPTION
Problem: We have floorRat and floorUnit for flooring a time unit, but
don't have the ceiling counterparts.

Solution: Define the ceiling functions.

Fixes: #126 