### PR TITLE
1.3 release

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,20 @@
+---
+name: Task
+about: Suggest a task for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Clarification and motivation
+
+<!--
+Clarify what you want to be done and why.
+-->
+
+# Acceptance criteria
+
+<!--
+Clarify how we can verify that the task is done.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,62 @@
+## Description
+
+<!--
+Describes the nature of your changes. If they are substantial, you should
+further subdivide this into a section describing the problem you are solving and
+another describing your solution.
+-->
+
+## Related issue(s)
+
+<!--
+- Short description of how the PR relates to the issue, including an issue link.
+For example
+- Fixed #1 by adding lenses to exported items
+
+Write 'None' if there are no related issues (which is discouraged).
+-->
+
+Fixes #
+
+## :white_check_mark: Checklist for your Pull Request
+
+Ideally a PR has all of the checkmarks set.
+
+If something in this list is irrelevant to your PR, you should still set this
+checkmark indicating that you are sure it is dealt with (be that by irrelevance).
+
+#### Related changes (conditional)
+
+- Tests
+  - [ ] If I added new functionality, I added tests covering it.
+  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
+        silently reappearing again.
+
+- Documentation
+  - [ ] I checked whether I should update the docs and did so if necessary:
+    - [README](https://github.com/serokell/o-clock/tree/master/README.md)
+    - Haddock
+
+- Public contracts
+  - [ ] Any modifications of public contracts comply with the [Evolution
+  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
+  - [ ] I added an entry to the [changelog](https://github.com/serokell/o-clock/tree/master/CHANGELOG.md) if my changes are visible to the users
+        and
+  - [ ] provided a migration guide for breaking changes if possible
+
+#### Stylistic guide (mandatory)
+
+- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
+- [ ] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
+
+#### ✓ Release Checklist
+
+- [ ] I updated the version number in `o-clock.cabal`.
+- [ ] I updated the [changelog](https://github.com/serokell/o-clock/tree/master/CHANGELOG.md) and moved everything
+      under the "Unreleased" section to a new section for this release version.
+- [ ] If any definitions (functions, type classes, instances, etc) were added,
+      I added [`@since` haddock annotations](https://haskell-haddock.readthedocs.io/en/latest/markup.html#since).
+- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/o-clock/releases) page,
+      with a summary of all user-facing changes.
+    *  I made sure a tag was created using the format `vX.Y.Z`
+- [ ] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/o-clock).

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,5 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: .github/pull_request_template.md .github/issue_template.md
+Copyright: 2022 Serokell <https://serokell.io>
+License: Unlicense

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The change log is available [on GitHub][2].
 Unreleased
 =====
 
+1.3
+=====
+
 * [#129](https://github.com/serokell/o-clock/pull/129)
   + Deprecate `toNum`: may cause accidental flooring.
   + Add the `toFractional` function to avoid the accidental flooring.

--- a/LICENSES/Unlicense.txt
+++ b/LICENSES/Unlicense.txt
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/o-clock.cabal
+++ b/o-clock.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 -- SPDX-License-Identifier: MPL-2.0
 
 name:                o-clock
-version:             1.2.1.1
+version:             1.3
 synopsis:            Type-safe time library.
 description:         See README.md for details.
 homepage:            https://github.com/serokell/o-clock

--- a/src/Time/Units.hs
+++ b/src/Time/Units.hs
@@ -3,8 +3,8 @@
 -- SPDX-License-Identifier: MPL-2.0
 
 {-# LANGUAGE AllowAmbiguousTypes        #-}
-{-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE CPP                        #-}
+{-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE ExplicitForAll             #-}
@@ -83,12 +83,12 @@ import Text.ParserCombinators.ReadP (ReadP, char, munch1, option, pfail, (+++))
 import Text.ParserCombinators.ReadPrec (ReadPrec, lift)
 
 #ifdef HAS_aeson
-import Data.Aeson (ToJSON (..), FromJSON (..), withText)
-import Text.Read (readMaybe)
+import Data.Aeson (FromJSON (..), ToJSON (..), withText)
 import qualified Data.Text as Text
+import Text.Read (readMaybe)
 #endif
 
-import Time.Rational (type (*), type (/), type (:%), KnownDivRat, Rat, RatioNat, KnownRat, ratVal)
+import Time.Rational (KnownDivRat, KnownRat, Rat, RatioNat, ratVal, type (*), type (/), type (:%))
 
 import qualified Control.Concurrent as Concurrent
 import qualified System.CPUTime as CPUTime
@@ -322,6 +322,8 @@ floorUnit :: forall (unit :: Rat) . Time unit -> Time unit
 floorUnit = time . fromIntegral @Natural . floorRat
 
 -- | Returns the smallest integer greater than or equal to the given 'Time'.
+--
+-- @since 1.3
 ceilingRat :: forall b (unit :: Rat) . (Integral b) => Time unit -> b
 ceilingRat = ceiling . unTime
 
@@ -336,6 +338,7 @@ ceilingRat = ceiling . unTime
 >>> ceilingUnit $ ps 42
 42ps
 
+@since 1.3
 -}
 ceilingUnit :: forall (unit :: Rat) . Time unit -> Time unit
 ceilingUnit = time . fromIntegral @Natural . ceilingRat
@@ -385,6 +388,7 @@ __Examples:__
 >>> toFractional @Double $ hour (1 % 8)
 0.125
 
+@since 1.3
 -}
 toFractional :: forall r (unit :: Rat) . Fractional r => Time unit -> r
 toFractional = fromRational . toRational . unTime


### PR DESCRIPTION
#### ✓ Release Checklist

- [x] I updated the version number in `o-clock.cabal`.
- [x] I updated the [changelog](https://github.com/serokell/o-clock/tree/master/CHANGELOG.md) and moved everything
      under the "Unreleased" section to a new section for this release version.
- [x] If any definitions (functions, type classes, instances, etc) were added,
      I added [`@since` haddock annotations](https://haskell-haddock.readthedocs.io/en/latest/markup.html#since).
- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/o-clock/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created using the format `vX.Y.Z`
- [ ] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/o-clock).
