### PR TITLE
[Chore] Fix release number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The change log is available [on GitHub][2].
 Unreleased
 =====
 
-1.3
+1.3.0
 =====
 
 * [#129](https://github.com/serokell/o-clock/pull/129)

--- a/o-clock.cabal
+++ b/o-clock.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 -- SPDX-License-Identifier: MPL-2.0
 
 name:                o-clock
-version:             1.3
+version:             1.3.0
 synopsis:            Type-safe time library.
 description:         See README.md for details.
 homepage:            https://github.com/serokell/o-clock

--- a/src/Time/Units.hs
+++ b/src/Time/Units.hs
@@ -323,7 +323,7 @@ floorUnit = time . fromIntegral @Natural . floorRat
 
 -- | Returns the smallest integer greater than or equal to the given 'Time'.
 --
--- @since 1.3
+-- @since 1.3.0
 ceilingRat :: forall b (unit :: Rat) . (Integral b) => Time unit -> b
 ceilingRat = ceiling . unTime
 
@@ -338,7 +338,7 @@ ceilingRat = ceiling . unTime
 >>> ceilingUnit $ ps 42
 42ps
 
-@since 1.3
+@since 1.3.0
 -}
 ceilingUnit :: forall (unit :: Rat) . Time unit -> Time unit
 ceilingUnit = time . fromIntegral @Natural . ceilingRat
@@ -388,7 +388,7 @@ __Examples:__
 >>> toFractional @Double $ hour (1 % 8)
 0.125
 
-@since 1.3
+@since 1.3.0
 -}
 toFractional :: forall r (unit :: Rat) . Fractional r => Time unit -> r
 toFractional = fromRational . toRational . unTime


### PR DESCRIPTION
## Description

Quick fix: I accidentally bumped the version number to 1.3, but according to the [PVP](https://pvp.haskell.org/) it should have also have a minor number (in the form of `A.B.C`).
