### PR TITLE
[#132] Add Data instance to Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Unreleased
 
 * [#136](https://github.com/serokell/o-clock/pull/136)
   + Remove `toNum`.
+* [#139](https://github.com/serokell/o-clock/pull/139)
+  + Add `Data` instance to `Time`.
 
 1.3.0
 =====

--- a/src/Time/Units.hs
+++ b/src/Time/Units.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE ExplicitForAll             #-}
 {-# LANGUAGE FlexibleContexts           #-}
@@ -70,6 +71,7 @@ import Control.Monad (unless)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Char (isDigit, isLetter)
 import Data.Coerce (coerce)
+import Data.Data (Data)
 import Data.Foldable (foldl')
 import Data.Proxy (Proxy (..))
 import Data.Semigroup (Semigroup (..))
@@ -115,7 +117,7 @@ type Fortnight   = 2  * Week
 
 -- | Time unit is represented as type level rational multiplier with kind 'Rat'.
 newtype Time (rat :: Rat) = Time { unTime :: RatioNat }
-    deriving (Eq, Ord, Enum, Generic)
+    deriving (Eq, Ord, Enum, Generic, Data)
 
 -- | Addition is associative binary operation for 'Semigroup' of 'Time'.
 instance Semigroup (Time (rat :: Rat)) where


### PR DESCRIPTION
## Description

Problem: Currently, `o-clock` does not provide a `Data` instance for its `Time` type, which can be useful for using it together with some generics library such as `uniplate`.

Solution: Derive `Data` for `Time` with `DeriveDataTypeable`.

## Related issue(s)

Fixes #132 

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](https://github.com/serokell/o-clock/tree/master/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](https://github.com/serokell/o-clock/tree/master/CHANGELOG.md) if my changes are visible to the users
        and
  - [x] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style/blob/master/haskell.md).
